### PR TITLE
Add contributor bot

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,19 @@
+{
+    "files": [
+        "README.md"
+    ],
+    "imageSize": 100,
+    "contributorsPerLine": 7,
+    "contributorsSortAlphabetically": false,
+    "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+    "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+    "types": {
+        "custom": {
+            "symbol": "🔭",
+            "description": "A custom contribution type.",
+            "link": "[<%= symbol %>](<%= url %> \"<%= description %>\"),"
+        }
+    },
+    "skipCi": "true",
+    "contributors": []
+}


### PR DESCRIPTION
Ajout du Contributor bot https://allcontributors.org/, pour mettre en avant les développeurs qui font avancer le site