### PR TITLE
Fix prop type of component `Speakers`

### DIFF
--- a/pages/speakers.js
+++ b/pages/speakers.js
@@ -102,10 +102,12 @@ export default function Speakers({ speakers }) {
 }
 
 Speakers.propTypes = {
-    speakers: PropTypes.arrayOf({
-        slug: PropTypes.string.isRequired,
-        frontMatter: PropTypes.object.isRequired,
-    }).isRequired,
+    speakers: PropTypes.arrayOf(
+        PropTypes.shape({
+            slug: PropTypes.string.isRequired,
+            frontMatter: PropTypes.object.isRequired,
+        }),
+    ).isRequired,
 };
 
 export async function getStaticProps() {


### PR DESCRIPTION
**What**:

```console
$ yarn dev
...
Warning: Failed prop type: Property `speakers` of component `Speakers` has invalid PropType notation inside arrayOf.
    in Speakers (at _app.js:22)
    in MyApp
    in Unknown
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in Context.Provider
    in AppContainer
...
```

**Checklist**:

-   [ ] RFR, Ready for review label
