### PR TITLE
Tests fail locally when the French dates are displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "next dev",
         "test:watch": "jest --watch",
-        "test": "jest",
+        "test": "NODE_ICU_DATA=node_modules/full-icu jest",
         "build": "next build",
         "postbuild": "next-sitemap",
         "export": "next export && yarn build:rss",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "eslint-config-zyhou": "^0.0.6",
         "eslint-plugin-mdx": "^1.8.1",
         "eslint-plugin-testing-library": "^3.9.0",
+        "full-icu": "^1.3.1",
         "husky": "^4.2.5",
         "jest": "^26.5.0",
         "lint-staged": "^10.2.11",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "dev": "next dev",
-        "test:watch": "jest --watch",
+        "test:watch": "NODE_ICU_DATA=node_modules/full-icu jest --watch",
         "test": "NODE_ICU_DATA=node_modules/full-icu jest",
         "build": "next build",
         "postbuild": "next-sitemap",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,6 +4761,11 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+full-icu@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.1.tgz#e67fdf58523f1d1e0d9143b1542fe2024c1c8997"
+  integrity sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I'm fixing the tests which are broken due to bad date format. It occurs locally and not on Travis but it's easier to write tests when they run in every environment.

<!-- Why are these changes necessary? -->

**Why**:

Node doesn't include all the locales. But in the website, we convert dates to french using `Date().toLocaleDateString()`. By doing that, we have a mismatch inside the tests between the real date (English) and the expected result (French) `2020 M10 20, Tue` !== `mardi 20 octobre 2020`.

Everything works well in the browser because it includes the French locale. The browsers which don't have the french locale will have an English date. But it's not a problem outside of the tests.

<!-- How were these changes implemented? -->

**How**:

I added the `full-icu` package to dependencies to include the french locale. And we simply use it when running `jest`.

<!-- Have you done all of these things?  -->

**Checklist**:

-   [ ] ~~Documentation added to the README.md file~~
-   [x] Tests
-   [x] RFR, Ready for review label